### PR TITLE
feat: User 도메인 추가

### DIFF
--- a/src/main/java/com/gmg/jeukhaeng/auth/dto/KakaoUserInfo.java
+++ b/src/main/java/com/gmg/jeukhaeng/auth/dto/KakaoUserInfo.java
@@ -10,4 +10,5 @@ import lombok.NoArgsConstructor;
 public class KakaoUserInfo {
     private Long id;
     private String email;
+    private String nickname;
 }

--- a/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
@@ -16,7 +16,7 @@ public class StringSetConverter implements AttributeConverter<Set<String>, Strin
 
     @Override
     public String convertToDatabaseColumn(Set<String> attribute) {
-        return String.join(",", attribute);
+        return attribute == null ? "" : String.join(",", attribute);
     }
 
     @Override

--- a/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
@@ -21,6 +21,8 @@ public class StringSetConverter implements AttributeConverter<Set<String>, Strin
 
     @Override
     public Set<String> convertToEntityAttribute(String dbData) {
-        return dbData == null ? new HashSet<>() : new HashSet<>(List.of(dbData.split(",")));
+        return (dbData == null || dbData.trim().isEmpty())
+                ? new HashSet<>()
+                : new HashSet<>(List.of(dbData.split(",")));
     }
 }

--- a/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/entity/StringSetConverter.java
@@ -1,0 +1,26 @@
+package com.gmg.jeukhaeng.user.entity;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Set을 콤마(,)로 구분된 문자열로 변환하여 DB에 저장하고,
+ * DB에서 읽어올 때 다시 Set으로 변환하는 JPA AttributeConverter입니다.
+ */
+@Converter
+public class StringSetConverter implements AttributeConverter<Set<String>, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Set<String> attribute) {
+        return String.join(",", attribute);
+    }
+
+    @Override
+    public Set<String> convertToEntityAttribute(String dbData) {
+        return dbData == null ? new HashSet<>() : new HashSet<>(List.of(dbData.split(",")));
+    }
+}

--- a/src/main/java/com/gmg/jeukhaeng/user/entity/User.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/entity/User.java
@@ -1,0 +1,39 @@
+package com.gmg.jeukhaeng.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    private String nickname;
+
+    private String provider;
+    private String providerId;
+
+    @Column(name = "linked_providers")
+    @Convert(converter = StringSetConverter.class)
+    private Set<String> linkedProviders;
+
+    public void addLinkedProvider(String provider) {
+        if (this.linkedProviders == null) {
+            this.linkedProviders = new HashSet<>();
+        }
+        this.linkedProviders.add(provider);
+    }
+}

--- a/src/main/java/com/gmg/jeukhaeng/user/repository/UserRepository.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.gmg.jeukhaeng.user.repository;
+
+import com.gmg.jeukhaeng.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+}

--- a/src/main/java/com/gmg/jeukhaeng/user/service/UserService.java
+++ b/src/main/java/com/gmg/jeukhaeng/user/service/UserService.java
@@ -1,0 +1,50 @@
+package com.gmg.jeukhaeng.user.service;
+
+import com.gmg.jeukhaeng.user.entity.User;
+import com.gmg.jeukhaeng.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User findOrCreate(String provider, String providerId, String email, String nickname) {
+        return findUser(provider, providerId, email)
+                .orElseGet(() -> createUser(provider, providerId, email, nickname));
+    }
+
+    private Optional<User> findUser(String provider, String providerId, String email) {
+        // 1. provider + providerId 우선 조회
+        Optional<User> byProviderId = userRepository.findByProviderAndProviderId(provider, providerId);
+        if (byProviderId.isPresent()) {
+            return byProviderId;
+        }
+
+        // 2. email로 조회 후 provider 연결
+        return userRepository.findByEmail(email).map(user -> {
+            user.addLinkedProvider(provider);
+            return userRepository.save(user); // provider만 추가
+        });
+    }
+
+    private User createUser(String provider, String providerId, String email, String nickname) {
+        return userRepository.save(
+                User.builder()
+                        .email(email)
+                        .nickname(nickname)
+                        .provider(provider)
+                        .providerId(providerId)
+                        .linkedProviders(new HashSet<>(Set.of(provider)))
+                        .build()
+        );
+    }
+}


### PR DESCRIPTION
## Issue
- close #6 

## 기능 요약

- User 엔티티 및 UserService 구현
- 소셜 로그인(Kakao) 시 사용자 자동 등록 또는 연동
- provider 중복 방지 및 linkedProviders 관리
- JWT 발급 시 User 정보 연동

## 주요 변경사항

- User 엔티티 추가 (email, provider, providerId, linkedProviders 등)
- UserService.findOrCreate() 로직 구현
- KakaoOAuthService에 UserService 연동
- 카카오 로그인 시 DB 저장 및 JWT 발급 완료 처리